### PR TITLE
GlobbingProvider: Match directory paths against glob patterns correctly

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="Ramstack.Globbing" Version="2.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Ramstack.FileProviders.Globbing/GlobbingFileProvider.cs
+++ b/src/Ramstack.FileProviders.Globbing/GlobbingFileProvider.cs
@@ -92,7 +92,7 @@ public sealed class GlobbingFileProvider : IFileProvider
     /// <see langword="true" /> if the file is included;
     /// otherwise, <see langword="false" />.
     /// </returns>
-    internal bool IsFileIncluded(string path) =>
+    private bool IsFileIncluded(string path) =>
         !PathHelper.IsMatch(path, _excludes) && PathHelper.IsMatch(path, _patterns);
 
     /// <summary>

--- a/src/Ramstack.FileProviders.Globbing/Internal/PathHelper.cs
+++ b/src/Ramstack.FileProviders.Globbing/Internal/PathHelper.cs
@@ -1,0 +1,339 @@
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+using Ramstack.Globbing;
+
+namespace Ramstack.FileProviders.Internal;
+
+/// <summary>
+/// Provides helper methods for path manipulations.
+/// </summary>
+internal static class PathHelper
+{
+    /// <summary>
+    /// Determines whether the specified path matches any of the specified patterns.
+    /// </summary>
+    /// <param name="path">The path to match for a match.</param>
+    /// <param name="patterns">An array of patterns to match against the path.</param>
+    /// <returns>
+    /// <see langword="true" /> if the path matches any of the patterns;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsMatch(scoped ReadOnlySpan<char> path, string[] patterns)
+    {
+        foreach (var pattern in patterns)
+            if (Matcher.IsMatch(path, pattern, MatchFlags.Unix))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified path partially matches any of the specified patterns.
+    /// </summary>
+    /// <param name="path">The path to be partially matched.</param>
+    /// <param name="patterns">An array of patterns to match against the path.</param>
+    /// <returns>
+    /// <see langword="true" /> if the path partially matches any of the patterns;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsPartialMatch(scoped ReadOnlySpan<char> path, string[] patterns)
+    {
+        Debug.Assert(path is not "/");
+
+        var count = CountPathSegments(path);
+
+        foreach (var pattern in patterns)
+            if (Matcher.IsMatch(path, GetPartialPattern(pattern, count), MatchFlags.Unix))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Counts the number of segments in the specified path.
+    /// </summary>
+    /// <param name="path">The path to count segments for.</param>
+    /// <returns>
+    /// The number of segments in the path.
+    /// </returns>
+    public static int CountPathSegments(scoped ReadOnlySpan<char> path)
+    {
+        var count = 0;
+        var iterator = new PathSegmentIterator();
+        ref var s = ref Unsafe.AsRef(in MemoryMarshal.GetReference(path));
+        var length = path.Length;
+
+        while (true)
+        {
+            var r = iterator.GetNext(ref s, length);
+
+            if (r.start != r.final)
+                count++;
+
+            if (r.final == length)
+                break;
+        }
+
+        if (count == 0)
+            count = 1;
+
+        return count;
+    }
+
+    /// <summary>
+    /// Returns a partial pattern from the specified pattern string based on the specified depth.
+    /// </summary>
+    /// <param name="pattern">The pattern string to extract from.</param>
+    /// <param name="depth">The depth level to extract the partial pattern up to.</param>
+    /// <returns>
+    /// A <see cref="ReadOnlySpan{T}"/> representing the partial pattern.
+    /// </returns>
+    public static ReadOnlySpan<char> GetPartialPattern(string pattern, int depth)
+    {
+        Debug.Assert(depth >= 1);
+
+        var iterator = new PathSegmentIterator();
+        ref var s = ref Unsafe.AsRef(in pattern.GetPinnableReference());
+        var length = pattern.Length;
+
+        while (true)
+        {
+            var r = iterator.GetNext(ref s, length);
+            if (r.start != r.final)
+                depth--;
+
+            if (depth < 1
+                || r.final == length
+                || IsGlobStar(ref s, r.start, r.final))
+                return MemoryMarshal.CreateReadOnlySpan(ref s, r.final);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool IsGlobStar(ref char s, int index, int final) =>
+            index + 2 == final && Unsafe.ReadUnaligned<int>(
+                ref Unsafe.As<char, byte>(
+                    ref Unsafe.Add(ref s, (nint)(uint)index))) == ('*' << 16 | '*');
+    }
+
+    #region Vector helper methods
+
+    /// <summary>
+    /// Loads a 256-bit vector from the specified source.
+    /// </summary>
+    /// <param name="source">The source from which the vector will be loaded.</param>
+    /// <param name="offset">The offset from the <paramref name="source"/> from which the vector will be loaded.</param>
+    /// <returns>
+    /// The loaded 256-bit vector.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector256<ushort> LoadVector256(ref char source, nint offset) =>
+        Unsafe.ReadUnaligned<Vector256<ushort>>(
+            ref Unsafe.As<char, byte>(ref Unsafe.Add(ref source, offset)));
+
+    /// <summary>
+    /// Loads a 128-bit vector from the specified source.
+    /// </summary>
+    /// <param name="source">The source from which the vector will be loaded.</param>
+    /// <param name="offset">The offset from <paramref name="source"/> from which the vector will be loaded.</param>
+    /// <returns>
+    /// The loaded 128-bit vector.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<ushort> LoadVector128(ref char source, nint offset) =>
+        Unsafe.ReadUnaligned<Vector128<ushort>>(
+            ref Unsafe.As<char, byte>(
+                ref Unsafe.Add(ref source, offset)));
+
+    #endregion
+
+    #region Inner type: PathSegmentIterator
+
+    /// <summary>
+    /// Provides functionality to iterate over segments of a path.
+    /// </summary>
+    private struct PathSegmentIterator
+    {
+        private int _last;
+        private nint _position;
+        private uint _mask;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PathSegmentIterator"/> structure.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public PathSegmentIterator() =>
+            _last = -1;
+
+        /// <summary>
+        /// Retrieves the next segment of the path.
+        /// </summary>
+        /// <param name="source">A reference to the starting character of the path.</param>
+        /// <param name="length">The total number of characters in the input path starting from <paramref name="source"/>.</param>
+        /// <returns>
+        /// A tuple containing the start and end indices of the next path segment.
+        /// <c>start</c> indicates the beginning of the segment, and <c>final</c> satisfies
+        /// the condition that <c>final - start</c> equals the length of the segment.
+        /// The end of the iteration is indicated by <c>final</c> being equal to the length of the path.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int start, int final) GetNext(ref char source, int length)
+        {
+            var start = _last + 1;
+
+            while ((int)_position < length)
+            {
+                if ((Avx2.IsSupported || Sse2.IsSupported || AdvSimd.Arm64.IsSupported) && _mask != 0)
+                {
+                    var offset = BitOperations.TrailingZeroCount(_mask);
+                    if (AdvSimd.IsSupported)
+                    {
+                        //
+                        // On ARM, ExtractMostSignificantBits returns a mask where each bit
+                        // represents one vector element (1 bit per ushort), so offset
+                        // directly corresponds to the element index
+                        //
+                        _last = (int)(_position + (nint)(uint)offset);
+
+                        //
+                        // Clear the bits for the current separator
+                        //
+                        _mask &= ~(1u << offset);
+                    }
+                    else
+                    {
+                        //
+                        // On x86, MoveMask (and ExtractMostSignificantBits on byte-based vectors)
+                        // returns a mask where each bit represents one byte (2 bits per ushort),
+                        // so we need to divide offset by 2 to get the actual element index
+                        //
+                        _last = (int)(_position + (nint)((uint)offset >> 1));
+
+                        //
+                        // Clear the bits for the current separator
+                        //
+                        _mask &= ~(0b_11u << offset);
+                    }
+
+                    //
+                    // Advance position to the next chunk when no separators remain in the mask
+                    //
+                    if (_mask == 0)
+                    {
+                        //
+                        // https://github.com/dotnet/runtime/issues/117416
+                        //
+                        // Precompute the stride size instead of calculating it inline
+                        // to avoid stack spilling. For some unknown reason, the JIT
+                        // fails to optimize properly when this is written inline, like so:
+                        // _position += Avx2.IsSupported
+                        //     ? Vector256<ushort>.Count
+                        //     : Vector128<ushort>.Count;
+                        //
+
+                        var stride = Avx2.IsSupported
+                            ? Vector256<ushort>.Count
+                            : Vector128<ushort>.Count;
+
+                        _position += stride;
+                    }
+
+                    return (start, _last);
+                }
+
+                if (Avx2.IsSupported && (int)_position + Vector256<ushort>.Count <= length)
+                {
+                    var chunk = LoadVector256(ref source, _position);
+                    var slash = Vector256.Create('/');
+                    var comparison = Avx2.CompareEqual(chunk, slash);
+
+                    //
+                    // Store the comparison bitmask and reuse it across iterations
+                    // as long as it contains non-zero bits.
+                    // This avoids reloading SIMD registers and repeating comparisons
+                    // on the same chunk of data.
+                    //
+                    _mask = (uint)Avx2.MoveMask(comparison.AsByte());
+
+                    //
+                    // Advance position to the next chunk when no separators found
+                    //
+                    if (_mask == 0)
+                        _position += Vector256<ushort>.Count;
+                }
+                else if (Sse2.IsSupported && !Avx2.IsSupported && (int)_position + Vector128<ushort>.Count <= length)
+                {
+                    var chunk = LoadVector128(ref source, _position);
+                    var slash = Vector128.Create('/');
+                    var comparison = Sse2.CompareEqual(chunk, slash);
+
+                    //
+                    // Store the comparison bitmask and reuse it across iterations
+                    // as long as it contains non-zero bits.
+                    // This avoids reloading SIMD registers and repeating comparisons
+                    // on the same chunk of data.
+                    //
+                    _mask = (uint)Sse2.MoveMask(comparison.AsByte());
+
+                    //
+                    // Advance position to the next chunk when no separators found
+                    //
+                    if (_mask == 0)
+                        _position += Vector128<ushort>.Count;
+                }
+                else if (AdvSimd.Arm64.IsSupported && (int)_position + Vector128<ushort>.Count <= length)
+                {
+                    var chunk = LoadVector128(ref source, _position);
+                    var slash = Vector128.Create('/');
+                    var comparison = AdvSimd.CompareEqual(chunk, slash);
+
+                    //
+                    // Store the comparison bitmask and reuse it across iterations
+                    // as long as it contains non-zero bits.
+                    // This avoids reloading SIMD registers and repeating comparisons
+                    // on the same chunk of data.
+                    //
+                    _mask = ExtractMostSignificantBits(comparison);
+
+                    //
+                    // Advance position to the next chunk when no separators found
+                    //
+                    if (_mask == 0)
+                        _position += Vector128<ushort>.Count;
+
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    static uint ExtractMostSignificantBits(Vector128<ushort> v)
+                    {
+                        var sum = AdvSimd.Arm64.AddAcross(
+                            AdvSimd.ShiftLogical(
+                                AdvSimd.And(v, Vector128.Create((ushort)0x8000)),
+                                Vector128.Create(-15, -14, -13, -12, -11, -10, -9, -8)));
+                        return sum.ToScalar();
+                    }
+                }
+                else
+                {
+                    for (; (int)_position < length; _position++)
+                    {
+                        var ch = Unsafe.Add(ref source, _position);
+                        if (ch == '/')
+                        {
+                            _last = (int)_position;
+                            _position++;
+
+                            return (start, _last);
+                        }
+                    }
+                }
+            }
+
+            return (start, length);
+        }
+    }
+
+    #endregion
+}

--- a/src/Ramstack.FileProviders.Globbing/Internal/PathHelper.cs
+++ b/src/Ramstack.FileProviders.Globbing/Internal/PathHelper.cs
@@ -61,7 +61,7 @@ internal static class PathHelper
     /// <returns>
     /// The number of segments in the path.
     /// </returns>
-    public static int CountPathSegments(scoped ReadOnlySpan<char> path)
+    private static int CountPathSegments(scoped ReadOnlySpan<char> path)
     {
         var count = 0;
         var iterator = new PathSegmentIterator();
@@ -93,7 +93,7 @@ internal static class PathHelper
     /// <returns>
     /// A <see cref="ReadOnlySpan{T}"/> representing the partial pattern.
     /// </returns>
-    public static ReadOnlySpan<char> GetPartialPattern(string pattern, int depth)
+    private static ReadOnlySpan<char> GetPartialPattern(string pattern, int depth)
     {
         Debug.Assert(depth >= 1);
 

--- a/tests/Ramstack.FileProviders.Tests/AbstractFileProviderTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/AbstractFileProviderTests.cs
@@ -61,12 +61,9 @@ public abstract class AbstractFileProviderTests
     {
         using var provider = CreateFileProvider();
 
-        var name = $"{Guid.NewGuid()}.txt";
-        var info = provider.GetFileInfo(name);
+        var info = provider.GetFileInfo("/project/8f723faf0ee0.txt");
 
-        Assert.That(
-            FilePath.GetFileName(info.Name),
-            Is.EqualTo(name));
+        Assert.That(info.Name, Is.EqualTo("8f723faf0ee0.txt").Or.EqualTo("/project/8f723faf0ee0.txt"));
         Assert.That(info.IsDirectory, Is.False);
         Assert.That(info.Exists, Is.False);
     }
@@ -76,8 +73,7 @@ public abstract class AbstractFileProviderTests
     {
         using var provider = CreateFileProvider();
 
-        var name = Guid.NewGuid().ToString();
-        var info = provider.GetDirectoryContents($"/{name}");
+        var info = provider.GetDirectoryContents("/project/c800f57d/7c71");
 
         Assert.That(info.Exists, Is.False);
     }

--- a/tests/Ramstack.FileProviders.Tests/FilePathTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/FilePathTests.cs
@@ -45,6 +45,7 @@ public class FilePathTests
 
     [TestCase("", "")]
     [TestCase("/", "")]
+    [TestCase("dir", "")]
     [TestCase("/dir", "/")]
     [TestCase("/dir/file", "/dir")]
     [TestCase("/dir/dir/", "/dir/dir")]

--- a/tests/Ramstack.FileProviders.Tests/GlobbingFileProviderTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/GlobbingFileProviderTests.cs
@@ -37,6 +37,47 @@ public class GlobbingFileProviderTests : AbstractFileProviderTests
     }
 
     [Test]
+    public void Glob_MatchStructures()
+    {
+        using var provider = CreateFileProvider();
+
+        Assert.That(
+            provider
+                .EnumerateDirectories("/", "**")
+                .OrderBy(f => f.FullName)
+                .Select(f => f.FullName)
+                .ToArray(),
+            Is.EquivalentTo(
+            [
+                "/project",
+                "/project/assets",
+                "/project/assets/fonts",
+                "/project/assets/images",
+                "/project/assets/images/backgrounds",
+                "/project/assets/styles"
+            ]));
+
+        Assert.That(
+            provider
+                .EnumerateFiles("/", "**")
+                .OrderBy(f => f.FullName)
+                .Select(f => f.FullName)
+                .ToArray(),
+            Is.EquivalentTo(
+            [
+                "/project/assets/fonts/Arial.ttf",
+                "/project/assets/fonts/Roboto.ttf",
+                "/project/assets/images/backgrounds/dark.jpeg",
+                "/project/assets/images/backgrounds/light.jpg",
+                "/project/assets/images/icon.svg",
+                "/project/assets/images/logo.png",
+                "/project/assets/styles/main.css",
+                "/project/assets/styles/print.css",
+                "/project/README.md"
+            ]));
+    }
+
+    [Test]
     public void ExcludedDirectory_HasNoFileNodes()
     {
         var provider = new GlobbingFileProvider(

--- a/tests/Ramstack.FileProviders.Tests/PrefixedFileProviderTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/PrefixedFileProviderTests.cs
@@ -12,12 +12,12 @@ public sealed class PrefixedFileProviderTests : AbstractFileProviderTests
             .GetMethod("ResolveGlobFilter", BindingFlags.Static | BindingFlags.NonPublic)!
             .CreateDelegate<Func<string, string, string?>>();
 
-    private const string Prefix = "solution/app";
-
-    private readonly TempFileStorage _storage = new TempFileStorage(Prefix);
+    private readonly TempFileStorage _storage = new TempFileStorage();
 
     protected override IFileProvider GetFileProvider() =>
-        new PrefixedFileProvider(Prefix, new PhysicalFileProvider(_storage.PrefixedPath, ExclusionFilters.None));
+        new PrefixedFileProvider("/project",
+            new PhysicalFileProvider(
+                Path.Join(_storage.Root, "project")));
 
     protected override DirectoryInfo GetDirectoryInfo() =>
         new DirectoryInfo(_storage.Root);

--- a/tests/Ramstack.FileProviders.Tests/SubFileProviderTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/SubFileProviderTests.cs
@@ -12,8 +12,10 @@ public sealed class SubFileProviderTests : AbstractFileProviderTests
         _storage.Dispose();
 
     protected override IFileProvider GetFileProvider() =>
-        new SubFileProvider("/project/docs", new PhysicalFileProvider(_storage.Root));
+        new SubFileProvider("/bin/app",
+            new PrefixedFileProvider("/bin/app",
+                new PhysicalFileProvider(_storage.Root)));
 
     protected override DirectoryInfo GetDirectoryInfo() =>
-        new DirectoryInfo(Path.Join(_storage.Root, "project", "docs"));
+        new DirectoryInfo(Path.Join(_storage.Root));
 }

--- a/tests/Ramstack.FileProviders.Tests/ZipFileProviderTests.cs
+++ b/tests/Ramstack.FileProviders.Tests/ZipFileProviderTests.cs
@@ -8,7 +8,11 @@ namespace Ramstack.FileProviders;
 public class ZipFileProviderTests : AbstractFileProviderTests
 {
     private readonly TempFileStorage _storage = new TempFileStorage();
-    private readonly string _path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    private readonly string _path =
+        Path.Combine(
+            Path.GetTempPath(),
+            Path.GetRandomFileName()
+            ) + ".zip";
 
     [OneTimeSetUp]
     public void Setup()


### PR DESCRIPTION
Previously, only full file paths were matched against glob patterns, allowing unintended directories to be enumerated. 

Now folder paths are properly validated against the patterns (e.g. `/assets/{images,styles}/**/*.{png,gif,css}`) correctly restricts access to only allowed paths.