### PR TITLE
Add ARM64 testing and expand test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
             name: Windows
           - id: ubuntu-latest
             name: Ubuntu
+          - id: ubuntu-24.04-arm
+            name: Ubuntu (ARM64)
 
     steps:
       - name: Install .NET
@@ -29,8 +31,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Solution
+      - name: Build (Debug)
         run: dotnet build -c Debug
 
-      - name: Test Projects
+      - name: Build (Release)
+        run: dotnet build -c Release
+
+      - name: Test (Debug)
         run: dotnet test -c Debug --no-build
+
+      - name: Test (Release)
+        run: dotnet test -c Release --no-build
+
+      - name: Test (Release, AVX2=0)
+        env:
+          DOTNET_EnableAVX2: "0"
+        run: dotnet test -c Release --no-build
+
+      - name: Test (Release, HWIntrinsic=0)
+        env:
+          DOTNET_EnableHWIntrinsic: "0"
+        run: dotnet test -c Release --no-build


### PR DESCRIPTION
- Add `ubuntu-24.04-arm` (ARM64) runner.
- Add AVX2/HWIntrinsic toggles.